### PR TITLE
Disable conflicting JSpreadsheet export

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -164,6 +164,8 @@ export class SpreadsheetWidget extends Widget {
 
     const options: jspreadsheet.JSpreadsheetOptions = {
       data: data,
+      // Disable export since its shortcut conflicts with JupyterLab's default save shortcut
+      allowExport: false,
       minDimensions: [1, 1],
       // minSpareCols: 1,
       // minSpareRows: 1,


### PR DESCRIPTION
Fixes https://github.com/jupyterlab-contrib/jupyterlab-spreadsheet-editor/issues/70.

Since its shortcut conflicts with JupyterLab's default save shortcut, and users can always use the `Download` option in JupyterLab's menu, I believe the simplest solution is to disable JSpreadsheet's export feature. 